### PR TITLE
add unit to ParVal

### DIFF
--- a/Schemas/protobufs/c_par_val.proto
+++ b/Schemas/protobufs/c_par_val.proto
@@ -5,4 +5,5 @@ package base;
 message ParVal {
   string id_parameter = 1; 
   bytes value = 2;
+  string unit = 3;
 }


### PR DESCRIPTION
Currently unit is a string - we should create a unit message and integrate with one of the existing Units of Measure ontologies e.g., http://www.semantic-web-journal.net/sites/default/files/swj177_7.pdf 

http://www.ontology-of-units-of-measure.org/resource/om-2/

https://github.com/HajoRijgersberg/OM