### PR TITLE
Update g_agent.proto

### DIFF
--- a/Schemas/protobufs/g_agent.proto
+++ b/Schemas/protobufs/g_agent.proto
@@ -19,7 +19,7 @@ enum AgentType {
 
 message Agent {
   string identifier = 1; // e.g., full name and surname or ID number.
-  AgentType type = 2;
+  AgentType type_agent = 2;
   repeated Classification classifications = 3; 
   repeated Agent agents = 4; 
 //  repeated Credential credentials = 5;


### PR DESCRIPTION
'type' is a reserved word in many languages. Changing 'type' to 'type_agent' to avoid problems.